### PR TITLE
Fix GCC compilation due to missing include

### DIFF
--- a/include/Voronoi.hpp
+++ b/include/Voronoi.hpp
@@ -6,6 +6,7 @@
 #include <deque>
 #include <set>
 #include <algorithm>
+#include <cstddef>
 
 namespace Voronoi
 {


### PR DESCRIPTION
Compiling with GCC 11.4 failed due to `<cstddef>` not being included, `ptrdiff_t` needs it.